### PR TITLE
Channel name fix

### DIFF
--- a/SamsungChanelEditor/MapChannel.cs
+++ b/SamsungChanelEditor/MapChannel.cs
@@ -76,7 +76,7 @@ namespace SamsChannelEditor
     {
       get
       {
-        return StringUtils.RemoveNulls(Encoding.Unicode.GetString(data, 65, 100));
+          return StringUtils.RemoveNulls(Encoding.BigEndianUnicode.GetString(data, 64, 100));
       }
     }
 


### PR DESCRIPTION
According to SamyGO Wiki 16 bit fields are Big Endian. Channel names in Russian now print correctly